### PR TITLE
fix bug of load user defined snippets

### DIFF
--- a/plugin/code_complete.vim
+++ b/plugin/code_complete.vim
@@ -72,7 +72,7 @@ if !exists("g:re")
 endif
 
 if !exists("g:user_defined_snippets")
-    let g:user_defined_snippets = "$VIMRUNTIME/plugin/my_snippets.vim"
+    let g:user_defined_snippets = ""
 endif
 
 " ----------------------------
@@ -271,7 +271,8 @@ let g:template['_']['xt'] = "\<c-r>=strftime(\"%Y-%m-%d %H:%M:%S\")\<cr>"
 
 " ---------------------------------------------
 " load user defined snippets
-exec "silent! runtime ".g:user_defined_snippets
+exec "silent! runtime plugin/my_snippets.vim"
+exec "silent! source ".g:user_defined_snippets
 
 
 " vim: set fdm=marker et :


### PR DESCRIPTION
1. fix bug of user defined snippets file cannot load when g:user_defined_snippets set to a path not in &runtimepath

    `runtime` cannot load file not in &runtimepath, use `source` is better.

2. adapter Vundle. when use Vundle to manage plugin, my_snippets.vim is not in $VIMRUNTIME/plugin

    Though my_snippets.vim file is in plugin directory and its suffix is `.vim` so it will auto load, many people like me are using Vundle now, make we no doubt.