### PR TITLE
Add new option for case-insensitive keyword search

### DIFF
--- a/plugin/code_complete.vim
+++ b/plugin/code_complete.vim
@@ -45,6 +45,9 @@
 "               g:user_defined_snippets
 "                   file name of user defined snippets.
 "
+"               g:CodeComplete_Ignorecase
+"                   use ignore case for keywords.
+
 "           key words:
 "               see "templates" section.
 "==================================================
@@ -161,14 +164,28 @@ endfunction
 function! ExpandTemplate(cword)
     "let cword = substitute(getline('.')[:(col('.')-2)],'\zs.*\W\ze\w*$','','g')
     if has_key(g:template,&ft)
+      if ( exists('g:CodeComplete_Ignorecase') && g:CodeComplete_Ignorecase )
+        if has_key(g:template[&ft],tolower(a:cword))
+            let s:jumppos = line('.')
+            return "\<c-w>" . g:template[&ft][tolower(a:cword)]
+        endif
+      else
         if has_key(g:template[&ft],a:cword)
             let s:jumppos = line('.')
             return "\<c-w>" . g:template[&ft][a:cword]
         endif
+      endif
     endif
-    if has_key(g:template['_'],a:cword)
-        let s:jumppos = line('.')
-        return "\<c-w>" . g:template['_'][a:cword]
+    if ( exists('g:CodeComplete_Ignorecase') && g:CodeComplete_Ignorecase )
+      if has_key(g:template['_'],tolower(a:cword))
+          let s:jumppos = line('.')
+          return "\<c-w>" . g:template['_'][tolower(a:cword)]
+      endif
+    else
+      if has_key(g:template['_'],a:cword)
+          let s:jumppos = line('.')
+          return "\<c-w>" . g:template['_'][a:cword]
+      endif
     endif
     return ''
 endfunction


### PR DESCRIPTION
I added a new option `g:CodeComplete_Ignorecase` and corresponding checks before using the dictionary functions to be able to use the template expansion with case-insensitive keyword search. This must be enabled with the new option which means that the default is still case-sensitive.

When using the new option, prior to the dictionary search the function `tolower` is used. All keywords in the snippet file can be written in lower letters and are also found when the typed word in Vim is in upper letters.

