### PR TITLE
Add possibility to use multiple user snippet files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ becomes:
     {
         `<...>`
     }
+
+### Code Snippets
+
+Custom snippet files can be used. The default file is
+[my_snippets.vim](plugin/my_snippets.vim) and is loaded by default. To add
+more custom snippet files (see [my_snippets.vim](plugin/my_snippets.vim) for
+the structure), use one of the following variables in your vimrc:
+
+``` viml
+let g:user_defined_snippets = "snippets/custom_snippets.vim"
+let g:user_defined_snippets = ["snippets/c_snippets.vim", "snippets/js_snippets.vim"]
+```

--- a/plugin/code_complete.vim
+++ b/plugin/code_complete.vim
@@ -289,7 +289,14 @@ let g:template['_']['xt'] = "\<c-r>=strftime(\"%Y-%m-%d %H:%M:%S\")\<cr>"
 " ---------------------------------------------
 " load user defined snippets
 exec "silent! runtime plugin/my_snippets.vim"
-exec "silent! source ".g:user_defined_snippets
-
+if type(g:user_defined_snippets) == v:t_string
+  exec "silent! runtime ".g:user_defined_snippets
+  exec "silent! source ".g:user_defined_snippets
+elseif type(g:user_defined_snippets) == v:t_list
+  for snippet in g:user_defined_snippets
+    exec "silent! runtime ".snippet
+    exec "silent! source ".snippet
+  endfor
+endif
 
 " vim: set fdm=marker et :


### PR DESCRIPTION
Instead of just using one custom snippet file, it would be nice to have the possibility to use multiple files. The PR changes the loading part to allow the definition of a list in vimrc. I added a new section in the readme to describe shortly the custom snippet part.

IMPORTANT: It is backwards-compatible. I first check if the variable is a string (used until this PR) and keep the existing code for that (except adding the runtime command for loading the snippet file). Only
if the variable is a list a for loop for loading multiple snippet files is used.